### PR TITLE
🔧 Add a target to run dev attached

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@ run-dev:
 	@echo "Building and running the development stack"
 	docker compose -f docker-compose-dev.yml up --build -d
 
+run-dev-attached:
+	@echo "Building and running the development stack in attached mode"
+	docker compose -f docker-compose-dev.yml up --build
+
 stop-dev:
 	@echo "Stopping"
 	docker compose -f docker-compose-dev.yml down


### PR DESCRIPTION
This patch adds a small target to the Makefile that is identical to `run-dev` except for the fact that it runs all the dockers attached. This is useful in development if you wish to know everything that is happening at the same time in the stack without having to manually run `docker compose logs -f` yourself.