### PR TITLE
📙 Added documentatin deployment scripts

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,8 @@
+# Documentation deployment
+
+The `deploy_docs.sh` script is meant to be called by a
+[CRON](https://manpages.ubuntu.com/manpages/xenial/fr/man8/cron.8.html) task
+to deploy the already built static documentation pages on the InsaLan VPS.
+
+The `mappings.txt` is meant to map a fetch URL with a path on the VPS to the
+deployed directories.

--- a/docs/deploy_docs.sh
+++ b/docs/deploy_docs.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# TODO Check for required executables
+
+function deploy_doc {
+	if [ "$#" -ne "2" ]; then
+		echo "Expected 2 arguments for deploy_doc, found $#" >&2
+		return
+	fi
+
+	SRC_URL=$1
+	DST_DIR=$2
+
+	TAR_GZ=${SRC_URL##*/}
+
+	curl -sL "$SRC_URL" --output "$TAR_GZ"
+
+	TO_DEPLOY=$(tar -tzf "$TAR_GZ" | head -1 | cut -f1 -d"/")
+
+	tar -xzf "$TAR_GZ" | head -1 | cut -f1 -d"/"
+
+	if [ -d "$DST_DIR" ]; then
+		mv "$DST_DIR" "$DST_DIR.old"
+	fi
+
+	mv "$TO_DEPLOY" "$DST_DIR"
+}
+
+# Fetch arguments
+MAPPINGS=$(cat ${1:-mappings.txt})
+
+# Create a temporary working directory
+TMP_DIR=$(mktemp -d)
+cd $TMP_DIR
+
+while read -r src_url dst_dir; do
+	deploy_doc $src_url $dst_dir
+done <<< $MAPPINGS
+
+# Clean-up temporary directory
+rm -rf $TMP_DIR

--- a/docs/mappings.txt
+++ b/docs/mappings.txt
@@ -1,2 +1,2 @@
-https://github.com/InsaLan/backend-insalan.fr/releases/latest/download/manuel.tar.gz /tmp/manuel
-
+https://github.com/InsaLan/backend-insalan.fr/releases/latest/download/manuel.tar.gz /srv/http/docs/backend
+https://github.com/InsaLan/manuel-utilisateur-site-web/releases/latest/download/manuel.tar.gz /srv/http/docs/non-technique

--- a/docs/mappings.txt
+++ b/docs/mappings.txt
@@ -1,0 +1,2 @@
+https://github.com/InsaLan/backend-insalan.fr/releases/latest/download/manuel.tar.gz /tmp/manuel
+


### PR DESCRIPTION
Added a script to automatically deploy documentation on the VPS (it's actually more like a "try to pull script" that will need a CRON job than an actual CD script, but we do what we can with the VPN limitations)

Still a few things to do:

- [ ] Add all static documentation sources with the right paths on the VPS
- [ ] Find a way to keep track of the last pulled versions to avoid pulling useless data