### PR TITLE
Remove mongodb logs

### DIFF
--- a/docker-compose-beta.yml
+++ b/docker-compose-beta.yml
@@ -80,7 +80,9 @@ services:
       - 5433
     networks:
       - backend
-
+    command: 
+    - '--logpath'
+    - '/dev/null'
 
   frontend:
     build: 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,9 @@ services:
       - 5433
     networks:
       - backend
+    command: 
+    - '--logpath'
+    - '/dev/null'
 
   frontend:
     build: ./frontend


### PR DESCRIPTION
Self explanatory, mongo is spamming the logs with crap, now it's not.