### PR TITLE
Add langate3000 to mappings.txt

### DIFF
--- a/docs/mappings.txt
+++ b/docs/mappings.txt
@@ -1,1 +1,2 @@
 https://github.com/InsaLan/backend-insalan.fr/releases/latest/download/manuel.tar.gz /srv/http/docs/backend
+https://github.com/InsaLan/langate3000/releases/latest/download/manuel.tar.gz /srv/http/docs/langate


### PR DESCRIPTION
This adds langate3000 documentation to the `mappings.txt` file. This way, it will automatically be deployed to [docs.insalan.fr](https://docs.insalan.fr) by [deploy_docs.sh](https://github.com/InsaLan/infra-insalan.fr/blob/main/docs/deploy_docs.sh) periodically.